### PR TITLE
Add bare repo worktree support to git-pull

### DIFF
--- a/git-pull
+++ b/git-pull
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # DESCRIPTION
-#   Pull all Git repositories within a given directory.
+#   Pull all Git repositories within a given directory. Supports both regular
+#   clones and bare repository worktree containers.
 #
 # USAGE
 #   git-pull [OPTIONS]
@@ -37,6 +38,54 @@ function usage() {
   echo "  -d, --directory DIR    Directory to use (optional, defaults to the current directory)"
   echo "  -h, --help             Show this help message"
   echo ""
+}
+
+# Pull the current branch and print the result.
+function do_pull() {
+  local output
+  output=$(git pull 2>&1)
+
+  if [[ "${output}" =~ Already[[:space:]]up[[:space:]]to[[:space:]]date\. ]]; then
+    echo -e "${green}Already up to date.${reset}"
+  elif [[ "${output}" =~ Successfully[[:space:]]rebased[[:space:]]and[[:space:]]updated ]]; then
+    echo -e "${green}Successfully rebased and updated${reset}"
+  elif [[ "${output}" =~ There[[:space:]]is[[:space:]]no[[:space:]]tracking[[:space:]]information[[:space:]]for[[:space:]]the[[:space:]]current[[:space:]]branch. ]]; then
+    echo -e "${yellow}There is no tracking information for the current branch."
+    git branch | grep "\*"
+    echo -e "${reset}"
+  elif [[ "${output}" =~ Updating[[:space:]][a-f0-9]+\.\.[a-f0-9]+ ]]; then
+    echo -e "${yellow}Updating"
+    echo "${output}"
+    echo -e "${reset}"
+  else
+    echo -e "${red}Error"
+    echo "${output}"
+    echo -e "${reset}"
+  fi
+}
+
+# Check out the default branch and set upstream tracking.
+function checkout_default() {
+  local output
+  if ! git checkout master >/dev/null 2>&1; then
+    echo -e "${red}Branch 'master' does not exist.${reset}"
+    if ! git checkout main >/dev/null 2>&1; then
+      echo -e "${red}Branch 'main' does not exist.${reset}"
+      return 1
+    else
+      output=$(git branch --set-upstream-to=origin/main main 2>&1)
+      if [[ "${output}" =~ error ]]; then
+        echo -e "${red}The requested upstream branch 'origin/main' does not exist.${reset}"
+        return 1
+      fi
+    fi
+  else
+    output=$(git branch --set-upstream-to=origin/master master 2>&1)
+    if [[ "${output}" =~ error ]]; then
+      echo -e "${red}The requested upstream branch 'origin/master' does not exist.${reset}"
+      return 1
+    fi
+  fi
 }
 
 master=false
@@ -90,57 +139,36 @@ eval "$(ssh-agent -s)" >/dev/null 2>&1 &&
 for d in "${dir}"/*; do
   [ -d "${d}" ] || continue
   basename "${d}"
+
+  # Bare repository (worktree container).
+  if [ "$(git -C "${d}" rev-parse --is-bare-repository 2>/dev/null)" = "true" ]; then
+    for w in "${d}"/*; do
+      [ -d "${w}" ] || continue
+      [ -f "${w}/.git" ] || continue
+      echo "  $(basename "${w}")"
+      pushd "${w}" >/dev/null || exit
+      do_pull
+      popd >/dev/null || exit
+    done
+    continue
+  fi
+
+  # Regular clone.
   if [ ! -d "${d}/.git" ]; then
     echo -e "${red}$(basename "${d}") is not a Git repository.${reset}"
     continue
   fi
 
   pushd "${d}" >/dev/null || exit
-
   if [ "${master}" == true ]; then
-    if ! git checkout master >/dev/null 2>&1; then
-      echo -e "${red}Branch 'master' does not exist.${reset}"
-      if ! git checkout main >/dev/null 2>&1; then
-        echo -e "${red}Branch 'main' does not exist.${reset}"
-        continue
-      else
-        output=$(git branch --set-upstream-to=origin/main main 2>&1)
-        if [[ "${output}" =~ error ]]; then
-          echo -e "${red}The requested upstream branch 'origin/main' does not exist.${reset}"
-          continue
-        fi
-      fi
-    else
-      output=$(git branch --set-upstream-to=origin/master master 2>&1)
-      if [[ "${output}" =~ error ]]; then
-        echo -e "${red}The requested upstream branch 'origin/master' does not exist.${reset}"
-        continue
-      fi
-    fi
+    checkout_default || {
+      popd >/dev/null || exit
+      continue
+    }
   fi
-
-  output=$(git pull 2>&1)
-
-  # Already up to date.
-  if [[ "${output}" =~ Already[[:space:]]up[[:space:]]to[[:space:]]date\. ]]; then
-    echo -e "${green}Already up to date.${reset}"
-  # Successfully rebased and updated.
-  elif [[ "${output}" =~ Successfully[[:space:]]rebased[[:space:]]and[[:space:]]updated ]]; then
-    echo -e "${green}Successfully rebased and updated${reset}"
-  # There is no tracking information for the current branch.
-  elif [[ "${output}" =~ There[[:space:]]is[[:space:]]no[[:space:]]tracking[[:space:]]information[[:space:]]for[[:space:]]the[[:space:]]current[[:space:]]branch. ]]; then
-    echo -e "${yellow}There is no tracking information for the current branch."
-    git branch | grep "\*"
-    echo -e "${reset}"
-  # Updating abc1234..def5678.
-  elif [[ "${output}" =~ Updating[[:space:]][a-f0-9]+\.\.[a-f0-9]+ ]]; then
-    echo -e "${yellow}Updating"
-    echo "${output}"
-    echo -e "${reset}"
-  else
-    echo -e "${red}Error"
-    echo "${output}"
-    echo -e "${reset}"
-  fi
+  do_pull
   popd >/dev/null || exit
 done
+
+# Clean up ssh-agent.
+ssh-agent -k >/dev/null 2>&1

--- a/git-worktree-init
+++ b/git-worktree-init
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# DESCRIPTION
+#   Convert a regular Git clone into a bare repository with a worktree for the
+#   default branch. This enables the bare-clone container pattern where each
+#   branch is a peer worktree directory.
+#
+# USAGE
+#   git-worktree-init [OPTIONS] <repo>
+#
+# ARGUMENTS
+#   REPO    Path to the Git repository to convert
+#
+# OPTIONS
+#   -h, --help    Show this help message
+#
+# EXAMPLES
+#   git-worktree-init transaction-service
+#   git-worktree-init ~/Function-Health/transaction-service
+
+# Colors
+red='\033[0;31m'
+green='\033[0;32m'
+reset='\033[0m'
+
+# Print usage information.
+function usage() {
+  echo "usage: git-worktree-init [OPTIONS] <repo>"
+  echo ""
+  echo "Arguments:"
+  echo "  REPO    Path to the Git repository to convert"
+  echo ""
+  echo "Options:"
+  echo "  -h, --help    Show this help message"
+  echo ""
+}
+
+repo=""
+
+# Parse command line arguments.
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      repo="$1"
+      shift
+      break
+      ;;
+  esac
+done
+
+if [ -z "${repo}" ]; then
+  echo -e "${red}ERROR: Specify a repository to convert.${reset}" >&2
+  usage
+  exit 1
+fi
+
+# Remove trailing slash.
+repo="${repo%/}"
+
+if [ ! -d "${repo}" ]; then
+  echo -e "${red}ERROR: ${repo} does not exist.${reset}" >&2
+  exit 1
+fi
+
+if [ ! -d "${repo}/.git" ]; then
+  if [ "$(git -C "${repo}" rev-parse --is-bare-repository 2>/dev/null)" = "true" ]; then
+    echo -e "${red}ERROR: ${repo} is already a bare repository.${reset}" >&2
+  else
+    echo -e "${red}ERROR: ${repo} is not a Git repository.${reset}" >&2
+  fi
+  exit 1
+fi
+
+cd "${repo}" || exit 1
+repo_abs=$(pwd)
+repo_parent=$(dirname "${repo_abs}")
+repo_name=$(basename "${repo_abs}")
+
+# Check for uncommitted changes.
+if [ -n "$(git status --porcelain)" ]; then
+  echo -e "${red}ERROR: Uncommitted changes. Commit or stash first.${reset}" >&2
+  exit 1
+fi
+
+# Check for unpushed commits.
+unpushed=$(git log --branches --not --remotes --oneline 2>/dev/null)
+if [ -n "${unpushed}" ]; then
+  echo -e "${red}ERROR: Unpushed commits. Push all branches first.${reset}" >&2
+  exit 1
+fi
+
+# Get remote URL.
+remote_url=$(git remote get-url origin 2>/dev/null)
+if [ -z "${remote_url}" ]; then
+  echo -e "${red}ERROR: No 'origin' remote found.${reset}" >&2
+  exit 1
+fi
+
+# Determine the default branch.
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "${default_branch}" ]; then
+  if git show-ref --verify --quiet refs/heads/master 2>/dev/null; then
+    default_branch="master"
+  elif git show-ref --verify --quiet refs/heads/main 2>/dev/null; then
+    default_branch="main"
+  else
+    echo -e "${red}ERROR: Cannot determine default branch.${reset}" >&2
+    exit 1
+  fi
+fi
+
+cd "${repo_parent}" || exit 1
+
+# Move existing clone to a temporary location.
+tmp="${repo_name}-worktree-tmp-$$"
+mv "${repo_name}" "${tmp}"
+
+# Clone as a bare repository.
+if ! git clone --bare "${remote_url}" "${repo_name}"; then
+  echo -e "${red}ERROR: Bare clone failed. Restoring original.${reset}" >&2
+  rm -rf "${repo_name}"
+  mv "${tmp}" "${repo_name}"
+  exit 1
+fi
+
+cd "${repo_name}" || exit 1
+
+# Fix the fetch refspec for worktree compatibility. By default, bare clones
+# map remote branches to local refs. This restores the standard remote
+# tracking layout so that git pull works inside worktrees.
+git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+git fetch origin >/dev/null 2>&1
+
+# Add a worktree for the default branch and set up tracking.
+git worktree add "${default_branch}" "${default_branch}" >/dev/null 2>&1
+git -C "${default_branch}" branch -u "origin/${default_branch}" >/dev/null 2>&1
+
+cd "${repo_parent}" || exit 1
+
+# Clean up the temporary clone.
+rm -rf "${tmp}"
+
+echo -e "${green}Converted ${repo_name} to bare clone with '${default_branch}' worktree.${reset}"


### PR DESCRIPTION
Adds bare repository worktree support to `git-pull` and introduces a new `git-worktree-init` script.

- **`git-pull`**: Extracts pull and checkout logic into `do_pull()` and `checkout_default()` functions. Detects bare repositories and iterates their worktrees, pulling each one. Cleans up `ssh-agent` on exit.
- **`git-worktree-init`**: Converts a regular Git clone into a bare repository with a worktree for the default branch. Validates preconditions (uncommitted changes, unpushed commits, missing remote) and rolls back on failure.