### PR TITLE
Update tmux layouts and add tmux-layout

### DIFF
--- a/tmux-layout
+++ b/tmux-layout
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# DESCRIPTION
+#   Apply a predefined tmux layout to the current window.
+#   Creates panes as needed to reach three panes, then applies the layout.
+#
+#   NOTE: This script is specific to my local development environment.
+#
+# USAGE
+#   tmux-layout <LAYOUT> [OPTIONS]
+#
+# ARGUMENTS
+#   LAYOUT    Layout to apply: "v" (vertical) or "h" (horizontal)
+#
+# OPTIONS
+#   -h, --help    Show this help message
+#
+# EXAMPLES
+#   tmux-layout v
+#   tmux-layout h
+
+# Colors
+red='\033[0;31m'
+reset='\033[0m'
+
+LAYOUT_V='ba62,308x253,0,0[308x36,0,0,8,308x152,0,37,10,308x63,0,190,9]'
+LAYOUT_H='8a4f,553x140,0,0{276x140,0,0,12,276x140,277,0[276x70,277,0,13,276x69,277,71,14]}'
+
+# Print usage information.
+function usage() {
+  echo "usage: tmux-layout <LAYOUT> [OPTIONS]"
+  echo ""
+  echo "Arguments:"
+  echo "  LAYOUT    Layout to apply: \"v\" or \"h\""
+  echo ""
+  echo "Options:"
+  echo "  -h, --help    Show this help message"
+  echo ""
+}
+
+LAYOUT=""
+
+# Parse command line arguments.
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -z "${LAYOUT}" ]]; then
+        LAYOUT="$1"
+      else
+        echo "Unknown argument: $1" >&2
+        usage
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${LAYOUT}" ]]; then
+  echo -e "${red}ERROR: layout argument is required.${reset}" >&2
+  usage
+  exit 1
+fi
+
+if [[ "${LAYOUT}" != "v" && "${LAYOUT}" != "h" ]]; then
+  echo -e "${red}ERROR: layout must be \"v\" or \"h\".${reset}" >&2
+  usage
+  exit 1
+fi
+
+if ! [ -x "$(command -v tmux)" ]; then
+  echo -e "${red}ERROR: tmux is not installed.${reset}" >&2
+  exit 1
+fi
+
+if [[ -z "${TMUX}" ]]; then
+  echo -e "${red}ERROR: not inside a tmux session.${reset}" >&2
+  exit 1
+fi
+
+PANE_COUNT=$(tmux list-panes | wc -l | tr -d ' ')
+PANES_NEEDED=3
+
+while [[ "${PANE_COUNT}" -lt "${PANES_NEEDED}" ]]; do
+  tmux split-window -v
+  PANE_COUNT=$((PANE_COUNT + 1))
+done
+
+if [[ "${LAYOUT}" == "v" ]]; then
+  tmux select-layout "${LAYOUT_V}"
+  tmux select-pane -t 1
+else
+  tmux select-layout "${LAYOUT_H}"
+  tmux select-pane -t 0
+fi

--- a/tmux-new-h
+++ b/tmux-new-h
@@ -2,8 +2,8 @@
 #
 # DESCRIPTION
 #   Spawn a new tmux session for a horizontal display.
-#   Creates a session using the name of the current directory with two evenly
-#   spaced vertical panes.
+#   Creates a session using the name of the current directory with a left pane
+#   and a right pane split into top and bottom.
 #
 #   NOTE: This script is specific to my local development environment.
 #
@@ -66,8 +66,9 @@ function tmux_new_h() {
   SESSION_NAME="${BASE_NAME}-${i}"
 
   tmux new-session -d -s "${SESSION_NAME}" \; \
+    split-window -h \; \
     split-window -v \; \
-    select-layout 'e58b,554x141,0,0{276x141,0,0,4,277x141,277,0,5}' \; \
+    select-layout '8a4f,553x140,0,0{276x140,0,0,12,276x140,277,0[276x70,277,0,13,276x69,277,71,14]}' \; \
     select-pane -t 0 \; \
     attach-session -t "${SESSION_NAME}"
 }

--- a/tmux-new-v
+++ b/tmux-new-v
@@ -2,8 +2,8 @@
 #
 # DESCRIPTION
 #   Spawn a new tmux session for a vertical display.
-#   Creates a session using the name of the current directory with three
-#   panes in a vertical layout.
+#   Creates a session using the name of the current directory with three panes
+#   in a vertical layout.
 #
 #   NOTE: This script is specific to my local development environment.
 #
@@ -66,9 +66,9 @@ function tmux_new_v() {
   SESSION_NAME="${BASE_NAME}-${i}"
 
   tmux new-session -d -s "${SESSION_NAME}" \; \
-    split-window -h \; \
-    split-window -h -t 1 \; \
-    select-layout '3b4e,309x254,0,0[309x37,0,0,0,309x151,0,38,1,309x64,0,190,2]' \; \
+    split-window -v \; \
+    split-window -v \; \
+    select-layout 'ba62,308x253,0,0[308x36,0,0,8,308x152,0,37,10,308x63,0,190,9]' \; \
     select-pane -t 1 \; \
     attach-session -t "${SESSION_NAME}"
 }


### PR DESCRIPTION
Updates `tmux-new-h` and `tmux-new-v` to use correct split directions and adds a new `tmux-layout` script for applying layouts to existing windows.

- **`tmux-new-h`**: Changes from a 2-pane layout to a 3-pane layout (left pane + right pane split into top and bottom).
- **`tmux-new-v`**: Fixes split direction from horizontal (`-h`) to vertical (`-v`) so panes stack correctly.
- **`tmux-layout`** (new): Applies a predefined layout (`v` or `h`) to the current tmux window, creating panes as needed to reach three.