### PR TITLE
Add clone summaries and pull stats

### DIFF
--- a/git-clone-bb
+++ b/git-clone-bb
@@ -18,6 +18,7 @@
 
 # Colors
 red='\033[0;31m'
+green='\033[0;32m'
 reset='\033[0m'
 
 # Print usage information.
@@ -85,10 +86,22 @@ $(curl -s -X GET \
   jq -r '.values[].links.clone[] | select(.name == "ssh") | .href')
 EOF_SSH_URLS
 
+cloned=()
+
 for ssh_url in "${ssh_urls[@]}"; do
   echo Cloning "${ssh_url}"...
   output=$(git clone "${ssh_url}" 2>&1)
   if echo "${output}" | grep -qi "already exists"; then
     echo -e "${red}Repository already exists.${reset}"
+  else
+    cloned+=("$(basename "${ssh_url}" .git)")
   fi
 done
+
+if ((${#cloned[@]} > 0)); then
+  echo ""
+  echo -e "${green}Newly cloned repositories:${reset}"
+  for repo in "${cloned[@]}"; do
+    echo "  ${repo}"
+  done
+fi

--- a/git-clone-gh
+++ b/git-clone-gh
@@ -51,6 +51,7 @@ exclude_patterns=()
 
 # Colors
 red='\033[0;31m'
+green='\033[0;32m'
 yellow='\033[0;33m'
 reset='\033[0m'
 
@@ -206,6 +207,8 @@ if ((${#exclude_patterns[@]} > 0)); then
   mapfile -t filtered < <(printf '%s\n' "${ssh_urls[@]}" | grep -v -E "${pattern}")
 fi
 
+cloned=()
+
 for ssh_url in "${filtered[@]}"; do
   echo Cloning "${ssh_url}"...
   output=$(git clone "${ssh_url}" 2>&1)
@@ -218,8 +221,18 @@ for ssh_url in "${filtered[@]}"; do
     echo -e "${yellow}To access this repository, you must use the HTTPS remote with a personal access token${reset}" >&2
     echo -e "${yellow}or SSH with an SSH key and passphrase that has been authorized for this organization.${reset}" >&2
     exit 1
+  else
+    cloned+=("$(basename "${ssh_url}" .git)")
   fi
 done
+
+if ((${#cloned[@]} > 0)); then
+  echo ""
+  echo -e "${green}Newly cloned repositories:${reset}"
+  for repo in "${cloned[@]}"; do
+    echo "  ${repo}"
+  done
+fi
 
 # Clean up ssh-agent.
 ssh-agent -k >/dev/null 2>&1

--- a/git-clone-gl
+++ b/git-clone-gl
@@ -33,6 +33,7 @@
 
 # Colors
 red='\033[0;31m'
+green='\033[0;32m'
 reset='\033[0m'
 
 # Print usage information.
@@ -128,13 +129,25 @@ EOF_URLS
   ((page++))
 done
 
+cloned=()
+
 for ssh_url in "${ssh_urls[@]}"; do
   echo Cloning "${ssh_url}"...
   output=$(git clone "${ssh_url}" 2>&1)
   if echo "${output}" | grep -qi "already exists"; then
     echo -e "${red}Repository already exists.${reset}"
+  else
+    cloned+=("$(basename "${ssh_url}" .git)")
   fi
 done
+
+if ((${#cloned[@]} > 0)); then
+  echo ""
+  echo -e "${green}Newly cloned repositories:${reset}"
+  for repo in "${cloned[@]}"; do
+    echo "  ${repo}"
+  done
+fi
 
 # Clean up ssh-agent.
 ssh-agent -k >/dev/null 2>&1

--- a/git-config-all
+++ b/git-config-all
@@ -103,14 +103,34 @@ if ! [ -x "$(command -v gsed)" ]; then
   exit 1
 fi
 
+# Configure a single repository.
+function do_config() {
+  git config user.name "${user_name}" &&
+    git config user.email "${user_email}"
+  old_url="$(git remote get-url origin)"
+  new_url=$(echo "${old_url}" | gsed -E "s/@(.*):/@${host}:/")
+  git remote set-url origin "${new_url}"
+}
+
 for d in *; do
-  if [ -d "${d}" ]; then
+  [ -d "${d}" ] || continue
+  basename "${d}"
+
+  # Bare repository (worktree container).
+  if [ "$(git -C "${d}" rev-parse --is-bare-repository 2>/dev/null)" = "true" ]; then
     pushd "${d}" >/dev/null || exit
-    git config user.name "${user_name}" &&
-      git config user.email "${user_email}"
-    old_url="$(git remote get-url origin)"
-    new_url=$(echo "${old_url}" | gsed -E "s/@(.*):/@${host}:/")
-    git remote set-url origin "${new_url}"
+    do_config
     popd >/dev/null || exit
+    continue
   fi
+
+  # Regular clone.
+  if [ ! -d "${d}/.git" ]; then
+    echo -e "${red}$(basename "${d}") is not a Git repository.${reset}"
+    continue
+  fi
+
+  pushd "${d}" >/dev/null || exit
+  do_config
+  popd >/dev/null || exit
 done

--- a/git-pull
+++ b/git-pull
@@ -27,6 +27,13 @@ green='\033[0;32m'
 yellow='\033[0;33m'
 reset='\033[0m'
 
+# Stats counters.
+up_to_date=0
+updated=0
+no_tracking=0
+not_git=0
+errors=0
+
 # Print usage information.
 function usage() {
   echo "usage: git-pull [OPTIONS]"
@@ -47,20 +54,25 @@ function do_pull() {
 
   if [[ "${output}" =~ Already[[:space:]]up[[:space:]]to[[:space:]]date\. ]]; then
     echo -e "${green}Already up to date.${reset}"
+    ((up_to_date++))
   elif [[ "${output}" =~ Successfully[[:space:]]rebased[[:space:]]and[[:space:]]updated ]]; then
     echo -e "${green}Successfully rebased and updated${reset}"
+    ((updated++))
   elif [[ "${output}" =~ There[[:space:]]is[[:space:]]no[[:space:]]tracking[[:space:]]information[[:space:]]for[[:space:]]the[[:space:]]current[[:space:]]branch. ]]; then
     echo -e "${yellow}There is no tracking information for the current branch."
     git branch | grep "\*"
     echo -e "${reset}"
+    ((no_tracking++))
   elif [[ "${output}" =~ Updating[[:space:]][a-f0-9]+\.\.[a-f0-9]+ ]]; then
     echo -e "${yellow}Updating"
     echo "${output}"
     echo -e "${reset}"
+    ((updated++))
   else
     echo -e "${red}Error"
     echo "${output}"
     echo -e "${reset}"
+    ((errors++))
   fi
 }
 
@@ -156,6 +168,7 @@ for d in "${dir}"/*; do
   # Regular clone.
   if [ ! -d "${d}/.git" ]; then
     echo -e "${red}$(basename "${d}") is not a Git repository.${reset}"
+    ((not_git++))
     continue
   fi
 
@@ -169,6 +182,16 @@ for d in "${dir}"/*; do
   do_pull
   popd >/dev/null || exit
 done
+
+total=$((up_to_date + updated + no_tracking + not_git + errors))
+echo ""
+echo "Stats:"
+echo "  Total: ${total}"
+echo "  Up to date: ${up_to_date}"
+echo "  Updated: ${updated}"
+echo "  Errors: ${errors}"
+echo "  No tracking: ${no_tracking}"
+echo "  Not a repository: ${not_git}"
 
 # Clean up ssh-agent.
 ssh-agent -k >/dev/null 2>&1


### PR DESCRIPTION
Adds end-of-run summaries to the git-clone and git-pull scripts.

- **git-clone-bb**, **git-clone-gh**, **git-clone-gl**: Track newly cloned repositories and list them at the end of a run.
- **git-config-all**: Extract repeated config logic into `do_config()` and add support for bare repositories (worktree containers).
- **git-pull**: Add stats counters (up to date, updated, errors, no tracking, not a repository) and print a summary at the end.