### PR TITLE
Add worktree support to remaining scripts

### DIFF
--- a/git-commit-counter
+++ b/git-commit-counter
@@ -143,8 +143,10 @@ repo_data_file=$(mktemp)
 results_file=$(mktemp)
 filtered_repos=$(mktemp)
 
-# Find all Git repositories.
+# Find all Git repositories (regular clones have .git dirs, worktrees have .git
+# files).
 find "${scan_dir}" -type d -name ".git" >"${repo_data_file}"
+find "${scan_dir}" -type f -name ".git" >>"${repo_data_file}"
 
 # Filter out excluded patterns.
 cat "${repo_data_file}" >"${filtered_repos}"
@@ -161,7 +163,7 @@ while read -r gitdir; do
   repo_name=$(basename "${repo_dir}")
 
   # Skip if not a valid Git repository.
-  if [ ! -f "${gitdir}/config" ]; then
+  if ! git -C "${repo_dir}" rev-parse --git-dir >/dev/null 2>&1; then
     continue
   fi
 

--- a/git-remote-v
+++ b/git-remote-v
@@ -66,10 +66,23 @@ fi
 for d in "${dir}"/*; do
   [ -d "${d}" ] || continue
   basename "${d}"
+
+  # Bare repository (worktree container).
+  if [ "$(git -C "${d}" rev-parse --is-bare-repository 2>/dev/null)" = "true" ]; then
+    pushd "${d}" >/dev/null || exit
+    echo -e "${green}"
+    git remote -v
+    echo -e "${reset}"
+    popd >/dev/null || exit
+    continue
+  fi
+
+  # Regular clone.
   if [ ! -d "${d}/.git" ]; then
     echo -e "${red}$(basename "${d}") is not a Git repository.${reset}"
     continue
   fi
+
   pushd "${d}" >/dev/null || exit
   echo -e "${green}"
   git remote -v

--- a/git-status
+++ b/git-status
@@ -64,14 +64,8 @@ else
   fi
 fi
 
-for d in "${dir}"/*; do
-  [ -d "${d}" ] || continue
-  basename "${d}"
-  if [ ! -d "${d}/.git" ]; then
-    echo -e "${red}$(basename "${d}") is not a Git repository.${reset}"
-    continue
-  fi
-  pushd "${d}" >/dev/null || exit
+function do_status() {
+  local output
   output=$(git status 2>&1)
   if [[ "${output}" =~ modified ]]; then
     echo -e "${red}Modified files${reset}"
@@ -82,5 +76,32 @@ for d in "${dir}"/*; do
   else
     echo -e "${green}Working tree clean${reset}"
   fi
+}
+
+for d in "${dir}"/*; do
+  [ -d "${d}" ] || continue
+  basename "${d}"
+
+  # Bare repository (worktree container).
+  if [ "$(git -C "${d}" rev-parse --is-bare-repository 2>/dev/null)" = "true" ]; then
+    for w in "${d}"/*; do
+      [ -d "${w}" ] || continue
+      [ -f "${w}/.git" ] || continue
+      echo "  $(basename "${w}")"
+      pushd "${w}" >/dev/null || exit
+      do_status
+      popd >/dev/null || exit
+    done
+    continue
+  fi
+
+  # Regular clone.
+  if [ ! -d "${d}/.git" ]; then
+    echo -e "${red}$(basename "${d}") is not a Git repository.${reset}"
+    continue
+  fi
+
+  pushd "${d}" >/dev/null || exit
+  do_status
   popd >/dev/null || exit
 done


### PR DESCRIPTION
Adds bare repo and worktree handling to `git-status`, `git-remote-v`, and `git-commit-counter`, matching the pattern already used by `git-pull` and `git-push`.

- `git-status`: Iterates worktrees inside bare repos and reports status for each.
- `git-remote-v`: Detects bare repos and shows remotes directly (worktrees share remotes).
- `git-commit-counter`: Finds both `.git` directories (regular clones) and `.git` files (worktrees). Switches validation to `git rev-parse --git-dir`.